### PR TITLE
docs: Generate new documentation structure

### DIFF
--- a/skald-ui/new_docs/ADSRNode.md
+++ b/skald-ui/new_docs/ADSRNode.md
@@ -1,0 +1,15 @@
+## ADSRNode
+### Purpose
+Represents an ADSR (Attack, Decay, Sustain, Release) envelope generator as a node in the graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/AdsrEnvelopeEditor.md
+++ b/skald-ui/new_docs/AdsrEnvelopeEditor.md
@@ -1,0 +1,18 @@
+## AdsrEnvelopeEditor
+### Purpose
+Provides a graphical interface for editing ADSR (Attack, Decay, Sustain, Release) envelope parameters. Users can drag control points to visually manipulate the envelope shape.
+
+### Props / Inputs
+| Prop      | Type                      | Description                                                                 |
+|-----------|---------------------------|-----------------------------------------------------------------------------|
+| `value`   | `AdsrData`                | An object containing the current `attack`, `decay`, `sustain`, and `release` values. |
+| `onChange`| `(newValue: AdsrData) => void` | Callback function that is called with the new ADSR data when the envelope is modified. |
+| `width`   | `number` (optional)       | The width of the SVG editor canvas. Defaults to `300`.                        |
+| `height`  | `number` (optional)       | The height of the SVG editor canvas. Defaults to `150`.                       |
+| `maxTime` | `number` (optional)       | The maximum time in seconds for the envelope's X-axis. Defaults to `4.0`.     |
+
+### Emitted Events / Outputs
+- Calls the `onChange` prop function with the updated `AdsrData` object whenever a control point is moved.
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/BpmSyncControl.md
+++ b/skald-ui/new_docs/BpmSyncControl.md
@@ -1,0 +1,15 @@
+## BpmSyncControl
+### Purpose
+A dropdown menu that allows the user to select a musical note division (e.g., "1/4", "1/8t") for parameters that need to be synchronized with the global BPM.
+
+### Props / Inputs
+| Prop       | Type                        | Description                                          |
+|------------|-----------------------------|------------------------------------------------------|
+| `value`    | `string`                    | The currently selected note division value.          |
+| `onChange` | `(newDivision: string) => void` | Callback function triggered when a new division is selected. |
+
+### Emitted Events / Outputs
+- Calls the `onChange` prop with the new string value when a selection is made.
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/CodePreviewPanel.md
+++ b/skald-ui/new_docs/CodePreviewPanel.md
@@ -1,0 +1,15 @@
+## CodePreviewPanel
+### Purpose
+Displays generated code with options to copy it or close the panel.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `code`    | `string`       | The code string to be displayed in the panel.|
+| `onClose` | `() => void`   | Function called when the close button is clicked. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/CustomSlider.md
+++ b/skald-ui/new_docs/CustomSlider.md
@@ -1,0 +1,23 @@
+## CustomSlider
+### Purpose
+A versatile slider component combined with a text input for precise value entry. It supports both linear and logarithmic scales and can be reset to a default value.
+
+### Props / Inputs
+| Prop           | Type                           | Description                                                              |
+|----------------|--------------------------------|--------------------------------------------------------------------------|
+| `min`          | `number`                       | The minimum value of the slider range.                                   |
+| `max`          | `number`                       | The maximum value of the slider range.                                   |
+| `value`        | `number`                       | The current controlled value of the slider.                              |
+| `onChange`     | `(newValue: number) => void`   | Callback function that is called with the new value when the slider or input changes. |
+| `scale`        | `'log' \| 'linear'` (optional) | The scale to use for the slider's movement. Defaults to `linear`.        |
+| `step`         | `number` (optional)            | The increment/decrement step used for arrow keys in the text input. Defaults to `0.01`. |
+| `defaultValue` | `number` (optional)            | The value to which the slider resets on Ctrl/Cmd+DoubleClick. Defaults to `0`. |
+| `onReset`      | `() => void` (optional)        | A callback function that is triggered when the slider is reset.          |
+| `className`    | `string` (optional)            | Allows passing a CSS class to the component's container.                 |
+
+### Emitted Events / Outputs
+- Calls the `onChange` prop with the new numeric value when the slider is moved or the text input is updated.
+- Calls the `onReset` prop when the user Ctrl/Cmd+DoubleClicks the component.
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/DelayNode.md
+++ b/skald-ui/new_docs/DelayNode.md
@@ -1,0 +1,15 @@
+## DelayNode
+### Purpose
+Represents a delay effect as a node in the graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/DistortionNode.md
+++ b/skald-ui/new_docs/DistortionNode.md
@@ -1,0 +1,15 @@
+## DistortionNode
+### Purpose
+Represents a distortion effect as a node in the graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/FMOperatorNode.md
+++ b/skald-ui/new_docs/FMOperatorNode.md
@@ -1,0 +1,15 @@
+## FMOperatorNode
+### Purpose
+Represents an FM (Frequency Modulation) Operator as a node in the graph, with distinct inputs for carrier and modulator signals.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/FilterNode.md
+++ b/skald-ui/new_docs/FilterNode.md
@@ -1,0 +1,15 @@
+## FilterNode
+### Purpose
+Represents a filter effect as a node in the graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/GraphOutputNode.md
+++ b/skald-ui/new_docs/GraphOutputNode.md
@@ -1,0 +1,15 @@
+## GraphOutputNode
+### Purpose
+Represents the final output of the audio graph. It only has an input and no output.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/GroupNode.md
+++ b/skald-ui/new_docs/GroupNode.md
@@ -1,0 +1,16 @@
+## GroupNode
+### Purpose
+A special node that acts as a container for other nodes, visually grouping them. It intelligently creates input and output handles based on the connections made to and from its child nodes.
+
+### Props / Inputs
+| Prop      | Type           | Description                                                               |
+|-----------|----------------|---------------------------------------------------------------------------|
+| `id`      | `string`       | The unique identifier of the group node, provided by React Flow.          |
+| `data`    | `object`       | An object containing node data, including an optional `label` for the header. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/InstrumentNode.md
+++ b/skald-ui/new_docs/InstrumentNode.md
@@ -1,0 +1,15 @@
+## InstrumentNode
+### Purpose
+Represents an instrument as a node within a React Flow graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing data for the node, including a `name` property. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/LFONode.md
+++ b/skald-ui/new_docs/LFONode.md
@@ -1,0 +1,15 @@
+## LFONode
+### Purpose
+Represents a Low-Frequency Oscillator (LFO) as a node in the graph. It acts as a signal source and has no inputs.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/MixerNode.md
+++ b/skald-ui/new_docs/MixerNode.md
@@ -1,0 +1,17 @@
+## MixerNode
+### Purpose
+Represents a mixer with a variable number of inputs and a single output.
+
+### Props / Inputs
+| Prop         | Type     | Description                                                        |
+|--------------|----------|--------------------------------------------------------------------|
+| `data`       | `object` | An object containing node data.                                    |
+| `data.label` | `string` | (Optional) A custom label for the node.                            |
+| `data.inputCount` | `number` | (Optional) The number of input handles to create. Defaults to 4. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/NamePromptModal.md
+++ b/skald-ui/new_docs/NamePromptModal.md
@@ -1,0 +1,15 @@
+## NamePromptModal
+### Purpose
+A modal dialog that prompts the user to enter a name.
+
+### Props / Inputs
+| Prop          | Type                  | Description                               |
+|---------------|-----------------------|-------------------------------------------|
+| `onNameConfirm` | `(name: string) => void` | Callback function when the name is confirmed. |
+| `onCancel`    | `() => void`          | Callback function when the modal is canceled. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/NoiseNode.md
+++ b/skald-ui/new_docs/NoiseNode.md
@@ -1,0 +1,15 @@
+## NoiseNode
+### Purpose
+Represents a noise generator as a node in the graph. It acts as a signal source and has no inputs.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/OscillatorNode.md
+++ b/skald-ui/new_docs/OscillatorNode.md
@@ -1,0 +1,20 @@
+## OscillatorNode
+### Purpose
+Represents an oscillator as a node in the graph, with inputs to control frequency and amplitude.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+#### Handles
+- **Target `input_freq`**: Controls the frequency of the oscillator.
+- **Target `input_amp`**: Controls the amplitude of the oscillator.
+- **Source `output`**: The output signal of the oscillator.
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/PannerNode.md
+++ b/skald-ui/new_docs/PannerNode.md
@@ -1,0 +1,15 @@
+## PannerNode
+### Purpose
+Represents a panner effect, which positions an audio signal in the stereo field.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/ParameterPanel.md
+++ b/skald-ui/new_docs/ParameterPanel.md
@@ -1,0 +1,23 @@
+## ParameterPanel
+### Purpose
+Renders a dynamic panel with controls to edit the parameters of a currently selected node from the graph.
+
+### Props / Inputs
+| Prop           | Type                                                     | Description                                                                          |
+|----------------|----------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `selectedNode` | `Node | null`                                            | The node currently selected in the React Flow graph.                                 |
+| `onUpdateNode` | `(nodeId: string, data: object, subNodeId?: string) => void` | Callback function to update the data of a node or a sub-node within an instrument/group. |
+| `allNodes`     | `Node[]`                                                 | An array of all nodes in the graph, used for context.                                |
+| `allEdges`     | `Edge[]`                                                 | An array of all edges in the graph.                                                  |
+| `bpm`          | `number`                                                 | The current beats per minute, used for BPM-syncable controls.                        |
+
+### Emitted Events / Outputs
+- Calls the `onUpdateNode` prop function when a parameter is changed.
+
+### Dependencies
+- `React`
+- `reactflow`
+- `CustomSlider`
+- `BpmSyncControl`
+- `AdsrEnvelopeEditor`
+- `XYPad`

--- a/skald-ui/new_docs/ReverbNode.md
+++ b/skald-ui/new_docs/ReverbNode.md
@@ -1,0 +1,15 @@
+## ReverbNode
+### Purpose
+Represents a reverb effect as a node in the graph.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/SampleHoldNode.md
+++ b/skald-ui/new_docs/SampleHoldNode.md
@@ -1,0 +1,15 @@
+## SampleHoldNode
+### Purpose
+Represents a Sample & Hold module as a node in the graph. It acts as a signal source and has no inputs.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/Sidebar.md
+++ b/skald-ui/new_docs/Sidebar.md
@@ -1,0 +1,27 @@
+## Sidebar
+### Purpose
+Provides the main user interface for creating nodes, controlling global settings like BPM, and triggering application-level actions like generating code, playback, and saving/loading the graph.
+
+### Props / Inputs
+| Prop                | Type                        | Description                                                                 |
+|---------------------|-----------------------------|-----------------------------------------------------------------------------|
+| `onGenerate`        | `() => void`                | Callback when the 'Generate' button is clicked.                             |
+| `onPlay`            | `() => void`                | Callback when the 'Play' button is clicked.                                 |
+| `onStop`            | `() => void`                | Callback when the 'Stop' button is clicked.                                 |
+| `isPlaying`         | `boolean`                   | Indicates if audio is currently playing.                                    |
+| `onSave`            | `() => void`                | Callback when the 'Save' button is clicked.                                 |
+| `onLoad`            | `() => void`                | Callback when the 'Load' button is clicked.                                 |
+| `onCreateInstrument`| `() => void`                | Callback to group selected nodes into an instrument.                        |
+| `onCreateGroup`     | `() => void`                | Callback to group selected nodes visually.                                  |
+| `canCreateInstrument` | `boolean`                 | Determines if the 'Create Instrument' button should be enabled.             |
+| `bpm`               | `number`                    | The current beats per minute of the application.                            |
+| `onBpmChange`       | `(newBpm: number) => void`  | Callback when the BPM value is changed.                                     |
+| `isLooping`         | `boolean`                   | Indicates if the playback is currently looping.                             |
+| `onLoopToggle`      | `() => void`                | Callback when the loop toggle button is clicked.                            |
+
+### Emitted Events / Outputs
+- Drag events for creating new nodes (`oscillator`, `noise`, etc.).
+- Calls various prop functions (`onGenerate`, `onPlay`, etc.) on user interaction.
+
+### Dependencies
+- `React`

--- a/skald-ui/new_docs/WavetableNode.md
+++ b/skald-ui/new_docs/WavetableNode.md
@@ -1,0 +1,20 @@
+## WavetableNode
+### Purpose
+Represents a wavetable oscillator, which generates sound by cycling through a table of waveform samples. It has inputs for frequency and table position.
+
+### Props / Inputs
+| Prop      | Type           | Description                                  |
+|-----------|----------------|----------------------------------------------|
+| `data`    | `object`       | An object containing node data, including an optional `label`. |
+
+#### Handles
+- **Target `input_freq`**: Controls the frequency of the oscillator.
+- **Target `input_pos`**: Controls the position within the wavetable.
+- **Source `output`**: The output signal of the oscillator.
+
+### Emitted Events / Outputs
+- None
+
+### Dependencies
+- `React`
+- `reactflow`

--- a/skald-ui/new_docs/XYPad.md
+++ b/skald-ui/new_docs/XYPad.md
@@ -1,0 +1,24 @@
+## XYPad
+### Purpose
+A two-dimensional control surface that allows the user to manipulate two values (X and Y) simultaneously by dragging a handle within a bounded area. It supports both linear and logarithmic scaling for each axis.
+
+### Props / Inputs
+| Prop     | Type                                       | Description                                                                 |
+|----------|--------------------------------------------|-----------------------------------------------------------------------------|
+| `xValue` | `number`                                   | The controlled value for the X-axis.                                        |
+| `yValue` | `number`                                   | The controlled value for the Y-axis.                                        |
+| `minX`   | `number`                                   | The minimum value of the X-axis range.                                      |
+| `maxX`   | `number`                                   | The maximum value of the X-axis range.                                      |
+| `minY`   | `number`                                   | The minimum value of the Y-axis range.                                      |
+| `maxY`   | `number`                                   | The maximum value of the Y-axis range.                                      |
+| `onChange`| `(values: { x: number; y: number }) => void` | Callback function that is called with the new `{x, y}` values when the user releases the handle. |
+| `xScale` | `'log' \| 'linear'` (optional)             | The scale to use for the X-axis. Defaults to `linear`.                      |
+| `yScale` | `'log' \| 'linear'` (optional)             | The scale to use for the Y-axis. Defaults to `linear`.                      |
+| `width`  | `number` (optional)                        | The width of the control pad. Defaults to `250`.                            |
+| `height` | `number` (optional)                        | The height of the control pad. Defaults to `200`.                           |
+
+### Emitted Events / Outputs
+- Calls the `onChange` prop with an object containing the new `x` and `y` values when the user finishes dragging the handle.
+
+### Dependencies
+- `React`


### PR DESCRIPTION
Analyzed the `skald-ui` component and service structure to create a fresh set of documentation.

- Created a `new_docs` directory to house the new documentation.
- Generated individual markdown files for each component, including main components, nodes, and controls.
- Each file follows a consistent template with sections for Purpose, Props, Emitted Events, and Dependencies.